### PR TITLE
Increase ncp timeout

### DIFF
--- a/.changeset/eight-lizards-listen.md
+++ b/.changeset/eight-lizards-listen.md
@@ -1,0 +1,5 @@
+---
+"eth-tech-tree": patch
+---
+
+increasing the timeout for ncp operation

--- a/src/actions/setup-challenge.ts
+++ b/src/actions/setup-challenge.ts
@@ -14,7 +14,7 @@ const copy = (source: string, destination: string, options?: ncp.Options) => new
         if (err) {
             reject(err);
         } else {
-            setTimeout(resolve, 10);
+            setTimeout(resolve, 100);
         }
     });
 });


### PR DESCRIPTION
A repo setup failed due to ncp's known issue. Increasing the timeout may help to avoid the problem. 