### PR TITLE
Check for required deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "merge-packages": "^0.1.6",
     "ncp": "^2.0.0",
     "pkg-install": "1.0.0",
+    "semver": "^7.6.3",
     "terminal-kit": "^3.1.1"
   },
   "packageManager": "yarn@3.5.0"

--- a/src/actions/setup-challenge.ts
+++ b/src/actions/setup-challenge.ts
@@ -91,8 +91,8 @@ export const setupChallenge = async (name: string, installLocation: string) => {
         console.log(chalk.green("Challenge setup completed successfully."));
         console.log("");
         console.log(chalk.cyan(`Now open this repository in your favorite code editor and look at the readme for instructions: ${targetDir}`));
-    } catch (error) {
-        console.error(chalk.red("An error occurred during challenge setup:"), error);
+    } catch (error: any) {
+        console.error(chalk.red("An error occurred during challenge setup:"), error.message);
     }
 }
 

--- a/src/actions/setup-challenge.ts
+++ b/src/actions/setup-challenge.ts
@@ -11,7 +11,7 @@ import { BASE_REPO, BASE_BRANCH, BASE_COMMIT } from "../config";
 import { DefaultRenderer, Listr, ListrTaskWrapper, SimpleRenderer } from "listr2";
 import chalk from "chalk";
 
-type RequiredSoftware = "node" | "git" | "yarn" | "foundryup";
+type RequiredDependency = "node" | "git" | "yarn" | "foundryup";
 
 // Sidestep for ncp issue https://github.com/AvianFlu/ncp/issues/127
 const copy = (source: string, destination: string, options?: ncp.Options) => new Promise((resolve, reject) => {
@@ -61,6 +61,10 @@ export const setupChallenge = async (name: string, installLocation: string) => {
 
     const tasks = new Listr([
         {
+            title: 'Checking for required dependencies',
+            task: () => checkUserDependencies()
+        },
+        {
             title: 'Setting up base repository',
             task: () => setupBaseRepo(targetDir)
         },
@@ -92,7 +96,7 @@ export const setupChallenge = async (name: string, installLocation: string) => {
     }
 }
 
-const checkDependencyInstalled = async (name: RequiredSoftware) => {
+const checkDependencyInstalled = async (name: RequiredDependency) => {
     try {
         await execa(name, ["--help"]);
     } catch(_) {
@@ -100,7 +104,7 @@ const checkDependencyInstalled = async (name: RequiredSoftware) => {
     }
 }
 
-const checkDependencyVersion = async (name: RequiredSoftware, requiredVersion: string | Range) => {
+const checkDependencyVersion = async (name: RequiredDependency, requiredVersion: string | Range) => {
     try {
         const userVersion = (await execa(name, ["--version"])).stdout;
         if (!semver.satisfies(userVersion, requiredVersion)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,6 +1630,7 @@ __metadata:
     pkg-install: 1.0.0
     rollup: 3.21.0
     rollup-plugin-auto-external: 2.0.0
+    semver: ^7.6.3
     terminal-kit: ^3.1.1
     tslib: 2.5.0
     typescript: 5.0.4
@@ -4154,6 +4155,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 4110ec5d015c9438f322257b1c51fe30276e5f766a3f64c09edd1d7ea7118ecbc3f379f3b69032bacf13116dc7abc4ad8ce0d7e2bd642e26b0d271b56b61a7d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Checks that the CLI user has the correct dependencies before installing a challenge. If they do not, they are not able to load the challenge. Closes #23 

### Details
- Adds [semver](https://github.com/npm/node-semver) as a dependency to help compare node version strings.
- Checks for the following:
1. `node` >=v18.17
2. any version of `yarn`
3. any version of `git`
4. any version of `foundryup`

### Notes
To test this locally, I've been editing the `checkDependencyInstalled()` and `checkDependencyVersion()` functions to throw the error at the start of the function

[Screencast from 2024-11-07 11-11-28.webm](https://github.com/user-attachments/assets/79fccdeb-f145-40a2-b00a-58c156eea742)
