### PR TITLE
Command validation

### DIFF
--- a/.changeset/heavy-apples-appear.md
+++ b/.changeset/heavy-apples-appear.md
@@ -1,0 +1,5 @@
+---
+"eth-tech-tree": patch
+---
+
+Update validation messages when submitting a completed CA for a challenge, Add searchable list when setting up or submitting with command, few extra bug-fixes/tweaks

--- a/src/actions/submit-challenge.ts
+++ b/src/actions/submit-challenge.ts
@@ -2,14 +2,15 @@ import { loadUserState } from "../utils/state-manager";
 import { submitChallengeToServer } from "../modules/api";
 import chalk from "chalk";
 import { input } from "@inquirer/prompts";
+import { isValidAddress } from "../utils/helpers";
 
 export async function submitChallenge(name: string, contractAddress?: string) {
     const { address: userAddress } = loadUserState();
     if (!contractAddress) {
         // Prompt the user for the contract address
         const question = {
-            message: "Completed challenge contract address on Sepolia:",
-            validate: (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value),
+            message: "What is the contract address of your completed challenge?:",
+            validate: (value: string) => isValidAddress(value) ? true : "Please enter a valid contract address",
         };
         const answer = await input(question);
         contractAddress = answer;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,18 +10,26 @@ import { TechTree } from ".";
 
 
 export async function cli(args: Args) {
-  const commands = await parseCommandArgumentsAndOptions(args);
-  const userState = loadUserState();
-  if (commands.command || commands.help) {
-    const parsedCommands = await promptForMissingCommandArgs(commands, userState);
-    await handleCommand(parsedCommands);
-  } else {
-    await renderIntroMessage();
-    await init(userState);
-    // Navigate tree
-    const techTree = new TechTree();
+  try {
+    const commands = await parseCommandArgumentsAndOptions(args);
+    const userState = loadUserState();
+    if (commands.command || commands.help) {
+      const parsedCommands = await promptForMissingCommandArgs(commands, userState);
+      await handleCommand(parsedCommands);
+    } else {
+      await renderIntroMessage();
+      await init(userState);
+      // Navigate tree
+      const techTree = new TechTree();
 
-    await techTree.start();
+      await techTree.start();
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'ExitPromptError') {
+      // Because canceling the promise can cause the inquirer prompt to throw we need to silence this error
+    } else {
+      throw error;
+    }
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ export async function cli(args: Args) {
     }
   } catch (error) {
     if (error instanceof Error && error.name === 'ExitPromptError') {
-      // Because canceling the promise can cause the inquirer prompt to throw we need to silence this error
+      // Because canceling the promise (e.g. ctrl+c) can cause the inquirer prompt to throw we need to silence this error
     } else {
       throw error;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export class TechTree {
             }
         } catch (error) {
             if (error instanceof Error && error.name === 'ExitPromptError') {
-                // Because canceling the promise can cause the inquirer prompt to throw we need to silence this error
+                // Because canceling the promise (e.g. ctrl+c) can cause the inquirer prompt to throw we need to silence this error
               } else {
                 throw error;
               }

--- a/src/tasks/parse-command-arguments-and-options.ts
+++ b/src/tasks/parse-command-arguments-and-options.ts
@@ -128,7 +128,7 @@ export async function promptForMissingCommandArgs(commands: CommandOptions, user
 
   if (command === "submit") {
     // Need user state so direct to promptForMissingUserState
-    await promptForMissingUserState(userState);
+    await promptForMissingUserState(userState, true);
 
     if (!challenge) {
       questions.push({

--- a/src/tasks/prompt-for-missing-user-state.ts
+++ b/src/tasks/prompt-for-missing-user-state.ts
@@ -10,7 +10,8 @@ const defaultOptions: Partial<IUser> = {
 };
 
 export async function promptForMissingUserState(
-  userState: IUser
+  userState: IUser,
+  skipInstallLocation: boolean = false
 ): Promise<IUser> {
   const userDevice = getDevice();
   let identifier = userState.address;
@@ -39,7 +40,7 @@ export async function promptForMissingUserState(
   }
 
   // Prompt for install location if it doesn't exist on device
-  if (!existingInstallLocation) {
+  if (!existingInstallLocation && !skipInstallLocation) {
     const answer = await input({
       message: "Where would you like to download the challenges?",
       default: defaultOptions.installLocation,
@@ -53,8 +54,8 @@ export async function promptForMissingUserState(
   }
   
   const { address, ens, installLocations, challenges, creationTimestamp } = user;
-  const thisDeviceLocation = installLocations.find((loc: {location: string, device: string}) => loc.device === userDevice);
-  const newState = { address, ens, installLocation: thisDeviceLocation.location, challenges, creationTimestamp };
+  const thisDeviceLocation = installLocations?.find((loc: {location: string, device: string}) => loc.device === userDevice);
+  const newState = { address, ens, installLocation: thisDeviceLocation?.location, challenges, creationTimestamp };
   if (JSON.stringify(userState) !== JSON.stringify(newState)) {
     // Save the new state locally
     await saveUserState(newState);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,9 @@
 import os from "os";
 import fs from "fs";
 import { IChallenge } from "../types";
+import { loadChallenges } from "./state-manager";
+import { fetchChallenges } from "../modules/api";
+import { Choice } from "../tasks/parse-command-arguments-and-options";
 
 export function wait(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -53,4 +56,14 @@ export const calculatePoints = (completedChallenges: Array<{ challenge: IChallen
           const points = pointsPerLevel[challenge!.level - 1] || 100;
           return total + points;
       }, 0);
+}
+
+export const searchChallenges = async (term: string = "") => {
+  const challenges = (await fetchChallenges()).filter((challenge: IChallenge) => challenge.enabled);
+  const choices = challenges.map((challenge: IChallenge) => ({
+      value: challenge.name,
+      name: challenge.label,
+      description: ""
+  }));
+  return choices.filter((choice: Choice<string>) => choice.name?.toLowerCase().includes(term.toLowerCase()));
 }


### PR DESCRIPTION
This PR changes the following:
- Update validation messages when submitting a completed CA for a challenge
- Don't ask for installLocation if using submit command
- Add searchable list when setting up or submitting with command
- Handle ExitPromptErrors throughout (instead of just in tree view)
