### PR TITLE
add `Total Gas Used` to Progress page

### DIFF
--- a/.changeset/two-times-retire.md
+++ b/.changeset/two-times-retire.md
@@ -1,0 +1,5 @@
+---
+"eth-tech-tree": minor
+---
+
+Add "Total Gas Used" to Progress and Leader Board views

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,8 +1,8 @@
-import os from "os";
 import fs from "fs";
-import { IChallenge } from "../types";
+import os from "os";
 import { fetchChallenges, getEnsAddress } from "../modules/api";
 import { Choice } from "../tasks/parse-command-arguments-and-options";
+import { IChallenge } from "../types";
 
 export function wait(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -69,6 +69,15 @@ export const calculatePoints = (completedChallenges: Array<{ challenge: IChallen
           const points = pointsPerLevel[challenge!.level - 1] || 100;
           return total + points;
       }, 0);
+}
+
+export const calculateTotalGasUsed = (completedChallenges: Array<{ challenge: IChallenge | undefined, completion?: { gasReport?: Array<{ functionName: string, gasUsed: number }> } }>): number => {
+  return completedChallenges
+    .reduce((total, challengeItem) => {
+      const gasReport = challengeItem.completion?.gasReport;
+      const challengeGasUsed = gasReport?.reduce((challengeTotal: number, report: { functionName: string, gasUsed: number }) => challengeTotal + report.gasUsed, 0) || 0;
+      return total + challengeGasUsed;
+    }, 0);
 }
 
 export const searchChallenges = async (term: string = "") => {

--- a/src/utils/leaderboard-view.ts
+++ b/src/utils/leaderboard-view.ts
@@ -1,5 +1,5 @@
-import { TreeNode } from "../types";
 import chalk from "chalk";
+import { TreeNode } from "../types";
 import { stripAnsi } from "./helpers";
 
 interface LeaderboardEntry {
@@ -39,7 +39,7 @@ export class LeaderboardView {
 
     private getEntryLabel(entry: LeaderboardEntry): string {
         const identifier = entry.ens || entry.address;
-        return chalk.white(`${this.getRankFormatting(entry.rank)}  | ${this.formatSpacing(chalk.yellow(entry.points.toLocaleString()), 8)} | ${chalk.green(identifier)}`);
+        return chalk.white(`${this.getRankFormatting(entry.rank)}  | ${this.formatSpacing(chalk.yellow(entry.points.toLocaleString()), 8)} | ${this.formatSpacing(chalk.cyan(entry.totalGasUsed.toLocaleString()), 14)} | ${chalk.green(identifier)}`);
     }
 
     private getRankFormatting(rank: number): string {
@@ -108,6 +108,6 @@ Total Gas Used: ${chalk.green(entry.totalGasUsed.toLocaleString())}
             }
         }
 
-        return chalk.bold(`${statement}\n\nTop Players\n   Rank  |  Points  |  Player`);
+        return chalk.bold(`${statement}\n\nTop Players\n${this.formatSpacing("Rank", 7, false)}  | ${this.formatSpacing("Points", 8)} | ${this.formatSpacing("Total Gas Used", 12)} | Player`);
     }
 } 

--- a/src/utils/progress-view.ts
+++ b/src/utils/progress-view.ts
@@ -1,6 +1,6 @@
-import { IUser, IChallenge, TreeNode } from "../types";
 import chalk from "chalk";
-import { calculatePoints } from "./helpers";
+import { IChallenge, IUser, TreeNode } from "../types";
+import { calculatePoints, calculateTotalGasUsed } from "./helpers";
 
 export class ProgressView {
     constructor(
@@ -18,6 +18,7 @@ export class ProgressView {
             .filter(c => c.challenge);
 
         const points = calculatePoints(completedChallenges);
+        const totalGasUsed = calculateTotalGasUsed(completedChallenges);
         const completionRate = (completedChallenges.length / this.challenges.filter(c => c.enabled).length * 100).toFixed(1);
 
         // Create completed challenges node with all completed challenges as children
@@ -44,17 +45,17 @@ export class ProgressView {
             label: "Progress",
             name: "stats",
             children: [...challengeNodes],
-            message: this.buildStatsMessage(points, completionRate)
+            message: this.buildStatsMessage(points, completionRate, totalGasUsed)
         };
 
         return statsNode;
     }
 
-    private buildStatsMessage(points: number, completionRate: string): string {
+    private buildStatsMessage(points: number, completionRate: string, totalGasUsed: number): string {
         const totalChallenges = this.challenges.filter(c => c.enabled).length;
         const completedChallenges = this.userState.challenges.filter(c => c.status === "success").length;
         return `Address: ${chalk.green(this.userState.ens || this.userState.address)}
-${chalk.yellow(`Points Earned: ${points.toLocaleString()}`)}
+${chalk.yellow(`Points Earned: ${points.toLocaleString()}\n${chalk.cyan(`Total Gas Used: ${totalGasUsed.toLocaleString()}`)}`)}
 
 Challenges Completed: ${chalk.blueBright(`${completedChallenges}/${totalChallenges} (${completionRate}%)`)}
 ${completedChallenges ? "Details:" : ""}`;


### PR DESCRIPTION
Related to #124 

Adds a `Total Gas Used` to the progress and leaderboard pages, to mirror [the website](https://github.com/BuidlGuidl/eth-tech-tree-website/pull/6).

### Progress view
<img width="1355" height="979" alt="image" src="https://github.com/user-attachments/assets/79c4fad1-91bf-43f8-8f74-523aa5b46bee" />

### Leaderboard view
<img width="1355" height="979" alt="image" src="https://github.com/user-attachments/assets/2ca3f04f-43f4-4630-a62e-bcf36e3929d1" />
