### PR TITLE
Require user signature to submit challenge

### DIFF
--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -56,14 +56,14 @@ export const upsertUser = async (userData: { address?: string, ens?: string, dev
 /**
  * Submit Challenge
  */
-export const submitChallengeToServer = async (userAddress: string, challengeName: string, contractAddress: string) => {
+export const submitChallengeToServer = async (userAddress: string, challengeName: string, contractAddress: string, signature: string) => {
   try {
     const response = await fetch(`${API_URL}/submit`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ challengeName, contractAddress, userAddress }),
+      body: JSON.stringify({ challengeName, contractAddress, userAddress, signature }),
     });
     const data = await response.json();
     return data;
@@ -103,5 +103,32 @@ export const fetchLeaderboard = async () => {
   } catch (error) {
     console.error('Error:', error);
     return [];
+  }
+};
+
+/**
+ * Get Authentication Message
+ */
+export const getAuthMessage = async (userAddress: string) => {
+  try {
+    const response = await fetch(`${API_URL}/message/${userAddress}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error('User not found');
+      }
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    
+    const data = await response.json();
+    return data.message;
+  } catch (error) {
+    console.error('Error fetching auth message:', error);
+    throw error;
   }
 };

--- a/src/utils/request-signature.ts
+++ b/src/utils/request-signature.ts
@@ -1,0 +1,9 @@
+import { SafeSigner } from "safe-signer";
+
+export const requestSignature = async (message: string) => {
+    const signer = new SafeSigner();
+    await signer.start(); 
+    const response = await signer.sendRequest({message} as any);
+    signer.stop();
+    return response;
+}


### PR DESCRIPTION
This is linked with [API PR #48](https://github.com/BuidlGuidl/eth-tech-tree-backend/pull/48)

### Why
We don't currently require any authentication to submit a challenge, and it is possible for anyone to send contract submissions for anyone else. 

### How
- Adds a step in the submission flow to request the user's signature (using [safe-signer](https://github.com/escottalexander/safe-signer)

### Notes
The screencast example is using a local version of `safe-signer`. Once it is prepped and published, we'll need to add `safe-signer` as dependency before merging this PR. 

[Screencast from 2025-08-27 14-22-11.webm](https://github.com/user-attachments/assets/85c7eec6-6fb6-4cfb-85eb-832ceed733fe)
